### PR TITLE
ci(build-and-release.yml): Update Setup Typst to v4

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,10 +34,10 @@ jobs:
           sudo mv fontawesome-free-6.4.2-desktop /usr/share/fonts
           sudo fc-cache -fv
         
-      - uses: yusancky/setup-typst@v3.1.0
+      - uses: typst-community/setup-typst@v4.2.0
         id: setup-typst
         with:
-          version: 'latest'
+          typst-version: 'latest'
 
       - name: Build documents
         run: for file in `ls *typ`; do typst compile $file; done


### PR DESCRIPTION
> [!WARNING] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://gist.github.com/yusancky/b676f56d40d6346dfc67ed477ca2ea1a) for more information.